### PR TITLE
Config irma schememanager

### DIFF
--- a/docs/pages/configuration/nuts-auth.rst
+++ b/docs/pages/configuration/nuts-auth.rst
@@ -16,6 +16,7 @@ auth.irmaConfigPath                     ""                                      
 auth.actingPartyCn                      ""                                      The acting party Common name used in contracts
 auth.skipautoUpdateIrmaSchemas          false                                   set if you want to skip the auto download of the irma schemas every 60 minutes
 auth.enableCORS                         false                                   Set if you want to allow CORS requests. This is useful when you want browsers to directly communicate with the nuts node
+auth.irmaSchemeManager                  pbdf                                    Allows selecting an IRMA scheme manager. During development this can ben irma-demo. Should be pdfb in strictMode
 ===================================     ======================================  ========================================
 
 As with all other properties for nuts-go, they can be set through yaml:

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mdp/qrterminal/v3 v3.0.0
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/nuts-foundation/nuts-crypto v0.0.0-20191015112225-206a68fc8f33
-	github.com/nuts-foundation/nuts-go-core v0.0.0-20191014142450-dd0fd3a25ffb
+	github.com/nuts-foundation/nuts-go-core v0.0.0-20191028080827-9058a6df915a
 	github.com/nuts-foundation/nuts-registry v0.0.0-20191016145829-6bcaa08ad25d
 	github.com/pkg/errors v0.8.1
 	github.com/privacybydesign/gabi v0.0.0-20190503104928-ce779395f4c9 // indirect
@@ -26,5 +26,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
+	golang.org/x/net v0.0.0-20191021144547-ec77196f6094 // indirect
+	golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 // indirect
 	gopkg.in/antage/eventsource.v1 v1.0.0-20150318155416-803f4c5af225 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -144,10 +144,10 @@ github.com/nuts-foundation/nuts-crypto v0.0.0-20191015112225-206a68fc8f33 h1:953
 github.com/nuts-foundation/nuts-crypto v0.0.0-20191015112225-206a68fc8f33/go.mod h1:hwwPkHU+ptE850C6DF+ha0dCClzeVEZE6ZlZoJmgfSc=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20191014142450-dd0fd3a25ffb h1:Sdh/K8bSx/PG/5pD5WArKu7JEksDOShZXvSVSXuOA88=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20191014142450-dd0fd3a25ffb/go.mod h1:tPPkfE9y+T+jTc8klZ0B8FXtc23p9NIpg5BjI+FIiEs=
-github.com/nuts-foundation/nuts-registry v0.0.0-20191014144721-4f3a38dc8a9b h1:aBBTdWExnLedd7LemDWYMCBiQzW2hPVtui4QLfI43Vk=
-github.com/nuts-foundation/nuts-registry v0.0.0-20191014144721-4f3a38dc8a9b/go.mod h1:lYE7NOSMGiR3TcSc3VQ66uk564o3qmsjbJGZ3UQPT9Q=
-github.com/nuts-foundation/nuts-registry v0.0.0-20191016095342-8ccb29c91d71 h1:48kXe+Q75ks1Ub4mOY1ltX2LX303LyNWL2widEtmd48=
-github.com/nuts-foundation/nuts-registry v0.0.0-20191016095342-8ccb29c91d71/go.mod h1:GoIUJryOXBLSYV1d5gOG3+ksRA2qyVvN2fI67YIWI8g=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20191025082623-e8edeb2448c6 h1:CCC8qdmfi2jVDtMX4nnchnNVR/tLcwmRLokHHMGszS4=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20191025082623-e8edeb2448c6/go.mod h1:+IeGzu5J8qlF4Jcol+mY+MRcLDIfJ8OQnQV4wDp887o=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20191028080827-9058a6df915a h1:Y0X6Vg28p5x0fQWQ9mfT1GeW+DOWOgOJLWfBznrOt6Y=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20191028080827-9058a6df915a/go.mod h1:+IeGzu5J8qlF4Jcol+mY+MRcLDIfJ8OQnQV4wDp887o=
 github.com/nuts-foundation/nuts-registry v0.0.0-20191016145829-6bcaa08ad25d h1:0mGb+u8ZjWn5IZadKJ1a+R3Ds5wYDOawB1xUVjZtrso=
 github.com/nuts-foundation/nuts-registry v0.0.0-20191016145829-6bcaa08ad25d/go.mod h1:GoIUJryOXBLSYV1d5gOG3+ksRA2qyVvN2fI67YIWI8g=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -265,6 +265,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191011234655-491137f69257 h1:ry8e2D+cwaV6hk7lb3aRTjjZo24shrbK0e11QEOkTIg=
 golang.org/x/net v0.0.0-20191011234655-491137f69257/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191021144547-ec77196f6094 h1:5O4U9trLjNpuhpynaDsqwCk+Tw6seqJz1EbqbnzHrc8=
+golang.org/x/net v0.0.0-20191021144547-ec77196f6094/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -289,6 +291,8 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
+golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/pkg/auth.go
+++ b/pkg/auth.go
@@ -35,6 +35,9 @@ const ConfEnableCORS = "enableCORS"
 // ConfActingPartyCN is the config key to provide the Acting party common name
 const ConfActingPartyCN = "actingPartyCn"
 
+// ConfIrmaSchemeManager allows selecting an IRMA scheme manager. During development this can ben irma-demo. Production should be pdfb
+const ConfIrmaSchemeManager = "irmaSchemeManager"
+
 // AuthClient is the interface which should be implemented for clients or mocks
 type AuthClient interface {
 	CreateContractSession(sessionRequest CreateSessionRequest, actingParty string) (*CreateSessionResult, error)
@@ -58,6 +61,7 @@ type AuthConfig struct {
 	Address                   string
 	PublicUrl                 string
 	IrmaConfigPath            string
+	IrmaSchemeManager         string
 	SkipAutoUpdateIrmaSchemas bool
 	ActingPartyCn             string
 	EnableCORS                bool
@@ -132,10 +136,13 @@ func (auth *Auth) CreateContractSession(sessionRequest CreateSessionRequest, act
 
 	// Step 3: Put the contract in an IMRA envelope
 	signatureRequest := irma.NewSignatureRequest(message)
+	schemeManager := auth.Config.IrmaSchemeManager
+
+	attribute := fmt.Sprintf("%s.%s", schemeManager, contract.SignerAttributes[0])
 	signatureRequest.Disclose = irma.AttributeConDisCon{
 		irma.AttributeDisCon{
 			irma.AttributeCon{
-				irma.NewAttributeRequest(contract.SignerAttributes[0]),
+				irma.NewAttributeRequest(attribute),
 			},
 		},
 	}
@@ -162,11 +169,11 @@ func (auth *Auth) CreateContractSession(sessionRequest CreateSessionRequest, act
 func printQrCode(qrcode string) {
 	config := qrterminal.Config{
 		HalfBlocks: false,
-		BlackChar: qrterminal.WHITE,
-		WhiteChar: qrterminal.BLACK,
-		Level: qrterminal.M,
-		Writer: os.Stdout,
-		QuietZone: 1,
+		BlackChar:  qrterminal.WHITE,
+		WhiteChar:  qrterminal.BLACK,
+		Level:      qrterminal.M,
+		Writer:     os.Stdout,
+		QuietZone:  1,
 	}
 	qrterminal.GenerateWithConfig(qrcode, config)
 }

--- a/pkg/contract.go
+++ b/pkg/contract.go
@@ -14,13 +14,14 @@ const timeLayout = "Monday, 2 January 2006 15:04:05"
 
 // Contract stores the properties of a contract
 type Contract struct {
-	Type               ContractType `json:"type"`
-	Version            Version      `json:"version"`
-	Language           Language     `json:"language"`
-	SignerAttributes   []string     `json:"signer_attributes"`
-	Template           string       `json:"template"`
-	TemplateAttributes []string     `json:"template_attributes"`
-	Regexp             string       `json:"-"`
+	Type                 ContractType `json:"type"`
+	Version              Version      `json:"version"`
+	Language             Language     `json:"language"`
+	SignerAttributes     []string     `json:"signer_attributes"`
+	SignerDemoAttributes []string     `json:"-"`
+	Template             string       `json:"template"`
+	TemplateAttributes   []string     `json:"template_attributes"`
+	Regexp               string       `json:"-"`
 }
 
 // Language of the contract in all caps. example: "NL"
@@ -44,22 +45,22 @@ var ErrInvalidContractText = errors.New("invalid contract text")
 // EN:PractitionerLogin:v1 Contract
 var contracts = map[Language]map[ContractType]map[Version]*Contract{
 	"NL": {"BehandelaarLogin": {"v1": &Contract{
-		Type:               "BehandelaarLogin",
-		Version:            "v1",
-		Language:           "NL",
-		SignerAttributes:   []string{"irma-demo.nuts.agb.agbcode"},
-		Template:           `NL:BehandelaarLogin:v1 Ondergetekende geeft toestemming aan {{acting_party}} om namens {{legal_entity}} en ondergetekende het Nuts netwerk te bevragen. Deze toestemming is geldig van {{valid_from}} tot {{valid_to}}.`,
-		TemplateAttributes: []string{"acting_party", "legal_entity", "valid_from", "valid_to"},
-		Regexp:             `NL:BehandelaarLogin:v1 Ondergetekende geeft toestemming aan (.+) om namens (.+) en ondergetekende het Nuts netwerk te bevragen. Deze toestemming is geldig van (.+) tot (.+).`,
+		Type:                 "BehandelaarLogin",
+		Version:              "v1",
+		Language:             "NL",
+		SignerAttributes:     []string{"nuts.agb.agbcode"},
+		Template:             `NL:BehandelaarLogin:v1 Ondergetekende geeft toestemming aan {{acting_party}} om namens {{legal_entity}} en ondergetekende het Nuts netwerk te bevragen. Deze toestemming is geldig van {{valid_from}} tot {{valid_to}}.`,
+		TemplateAttributes:   []string{"acting_party", "legal_entity", "valid_from", "valid_to"},
+		Regexp:               `NL:BehandelaarLogin:v1 Ondergetekende geeft toestemming aan (.+) om namens (.+) en ondergetekende het Nuts netwerk te bevragen. Deze toestemming is geldig van (.+) tot (.+).`,
 	}}},
 	"EN": {"PractitionerLogin": {"v1": &Contract{
-		Type:               "PractitionerLogin",
-		Version:            "v1",
-		Language:           "EN",
-		SignerAttributes:   []string{"irma-demo.nuts.agb.agbcode"},
-		Template:           `EN:PractitionerLogin:v1 Undersigned gives permission to {{acting_party}} to make request to the Nuts network on behalf of {{legal_entity}} and itself. This permission is valid from {{valid_from}} until {{valid_to}}.`,
-		TemplateAttributes: []string{"acting_party", "legal_entity", "valid_from", "valid_to"},
-		Regexp:             `EN:PractitionerLogin:v1 Undersigned gives permission to (.+) to make request to the Nuts network on behalf of (.+) and itself. This permission is valid from (.+) until (.+).`,
+		Type:                 "PractitionerLogin",
+		Version:              "v1",
+		Language:             "EN",
+		SignerAttributes:     []string{"nuts.agb.agbcode"},
+		Template:             `EN:PractitionerLogin:v1 Undersigned gives permission to {{acting_party}} to make request to the Nuts network on behalf of {{legal_entity}} and itself. This permission is valid from {{valid_from}} until {{valid_to}}.`,
+		TemplateAttributes:   []string{"acting_party", "legal_entity", "valid_from", "valid_to"},
+		Regexp:               `EN:PractitionerLogin:v1 Undersigned gives permission to (.+) to make request to the Nuts network on behalf of (.+) and itself. This permission is valid from (.+) until (.+).`,
 	}}},
 }
 
@@ -115,7 +116,7 @@ func (c Contract) extractParams(text string) (map[string]string, error) {
 	matches := matchResult[1:]
 
 	if len(matches) != len(c.TemplateAttributes) {
-		return nil, fmt.Errorf("%w: amount of template attributes does not match the amount of params: found: %d, expected %d",ErrInvalidContractText,  len(matches), len(c.TemplateAttributes))
+		return nil, fmt.Errorf("%w: amount of template attributes does not match the amount of params: found: %d, expected %d", ErrInvalidContractText, len(matches), len(c.TemplateAttributes))
 	}
 
 	result := make(map[string]string, len(matches))

--- a/pkg/irmacontract.go
+++ b/pkg/irmacontract.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	core "github.com/nuts-foundation/nuts-go-core"
 	irma "github.com/privacybydesign/irmago"
 	"github.com/sirupsen/logrus"
+	"strings"
 )
 
 // SignedIrmaContract holds the contract and additional methods to parse and validate.
@@ -39,18 +41,26 @@ func (sc *SignedIrmaContract) verifySignature(configuration *irma.Configuration)
 		return nil, err
 	}
 
+	var disclosedAttributes map[string]string
 	// wrapper around irma status result
 	validationResult := Invalid
 	if status == irma.ProofStatusValid {
 		validationResult = Valid
-	}
 
-	var disclosedAttributes map[string]string
+		// a contract needs attributes
+		if len(attributes) == 0 {
+			return nil, fmt.Errorf("contract does not have any attributes")
+		}
 
-	if len(attributes) > 0 {
 		// take the attributes rawvalue and add them to a list.
 		disclosedAttributes = make(map[string]string, len(attributes[0]))
 		for _, att := range attributes[0] {
+			// Check schemaManager. Only the pdbf root is accepted in strictMode.
+			schemaManager := strings.Split(*att.RawValue, ".")[0]
+			if core.NutsConfig().InStrictMode() && schemaManager != "pbdf" {
+				logrus.Infof("IRMA schemeManager %s is not valid in strictMode", schemaManager)
+				validationResult = Invalid
+			}
 			disclosedAttributes[att.Identifier.String()] = *att.RawValue
 		}
 	}

--- a/pkg/irmacontract.go
+++ b/pkg/irmacontract.go
@@ -7,7 +7,6 @@ import (
 	core "github.com/nuts-foundation/nuts-go-core"
 	irma "github.com/privacybydesign/irmago"
 	"github.com/sirupsen/logrus"
-	"strings"
 )
 
 // SignedIrmaContract holds the contract and additional methods to parse and validate.
@@ -56,8 +55,9 @@ func (sc *SignedIrmaContract) verifySignature(configuration *irma.Configuration)
 		disclosedAttributes = make(map[string]string, len(attributes[0]))
 		for _, att := range attributes[0] {
 			// Check schemaManager. Only the pdbf root is accepted in strictMode.
-			schemaManager := strings.Split(*att.RawValue, ".")[0]
-			if core.NutsConfig().InStrictMode() && schemaManager != "pbdf" {
+			schemaManager := att.Identifier.Root()
+			strictMode := core.NutsConfig().InStrictMode()
+			if strictMode && schemaManager != "pbdf" {
 				logrus.Infof("IRMA schemeManager %s is not valid in strictMode", schemaManager)
 				validationResult = Invalid
 			}


### PR DESCRIPTION
Allows configuring different IRMA schememanagers such as `irma-demo` in development/demo and `pbdf` in production.
Fix #11 