### PR TITLE
API now adheres to given validFrom/validTo

### DIFF
--- a/api/generated.go
+++ b/api/generated.go
@@ -10,7 +10,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"net/http"
-	"time"
 )
 
 // Contract defines model for Contract.
@@ -28,8 +27,8 @@ type ContractSigningRequest struct {
 	Language    Language    `json:"language"`
 	LegalEntity LegalEntity `json:"legalEntity"`
 	Type        Type        `json:"type"`
-	ValidFrom   *time.Time  `json:"valid_from,omitempty"`
-	ValidTo     *time.Time  `json:"valid_to,omitempty"`
+	ValidFrom   *string     `json:"valid_from,omitempty"`
+	ValidTo     *string     `json:"valid_to,omitempty"`
 	Version     Version     `json:"version"`
 }
 
@@ -510,3 +509,4 @@ func RegisterHandlers(router runtime.EchoRouter, si ServerInterface) {
 	router.GET("/auth/contract/:contractType", wrapper.GetContractByType)
 
 }
+

--- a/docs/_static/nuts-auth.yaml
+++ b/docs/_static/nuts-auth.yaml
@@ -181,12 +181,10 @@ components:
           $ref: "#/components/schemas/LegalEntity"
         valid_from:
           type: string
-          format: 'date-time'
           description: "ValidFrom describes the time from which this contract should be considered valid"
           example: "2019-06-24T14:32:00+02:00"
         valid_to:
           type: string
-          format: 'date-time'
           description: "ValidTo describes the time until this contract should be considered valid"
           example: "2019-12-24T14:32:00+02:00"
     CreateSessionResult:


### PR DESCRIPTION
Fixes #20

format in spec has also changed from date-time to none.....(code generation issue)

Signed-off-by: Wout Slakhorst <wout.slakhorst@nedap.com>