### PR TITLE
draft for JWT tokens postable to a rfc7523 style token endpoint

### DIFF
--- a/docs/pages/technical/nuts-jwt-token.rst
+++ b/docs/pages/technical/nuts-jwt-token.rst
@@ -13,6 +13,7 @@ The JWT is specified as:
         "aud": "https://target_token_endpoint",
         "usi": {...irma based signature...},
         "osi": {...hardware token sig...},
+        "con": {...additional context...},
         "ccn": "CN=client_common_name",
         "icn": "CN=issuer_common_name",
         "exp": max(time_from_irma_sign, some_limited_time),
@@ -46,6 +47,10 @@ User signature. This is the Irma signature presented to the user. Base64 encoded
 Osi
 ---
 Ops signature, optional signature coming from a hardware token, indicating the user belongs to the issuer organization. Can be linked to the Nuts registry.
+
+Con
+---
+Base64 encoded json representing key-value pairs for additional context for the requested access token. Such as patient and/or task flow selection.
 
 Ccn
 ---

--- a/docs/pages/technical/nuts-jwt-token.rst
+++ b/docs/pages/technical/nuts-jwt-token.rst
@@ -8,16 +8,24 @@ The JWT is specified as:
 .. code-block:: json
 
     {
-        "iss": "nuts",
-        "sub": "urn:oid:2.16.840.1.113883.2.4.6.1",
-        "nuts_signature": {...irma based signature...}
+        "iss": "urn:oid:2.16.840.1.113883.2.4.6.1:48000000",
+        "sub": "urn:oid:2.16.840.1.113883.2.4.6.1:12481248",
+        "aud": "https://target_token_endpoint",
+        "usi": {...irma based signature...},
+        "osi": {...hardware token sig...},
+        "ccn": "CN=client_common_name",
+        "icn": "CN=issuer_common_name",
+        "exp": max(time_from_irma_sign, some_limited_time),
+        "iat": "",
+        "jti": {unique-identifier}
     }
+
+`according to rfc7523 <https://tools.ietf.org/html/rfc7523>`_
 
 Iss
 ---
-The issuer in the JWT is always *nuts*.
-This allows the API of the care provider to switch between validation mechanisms:
-When the Issuer is *nuts* post the token to the token check endpoint, if not, do your usual checks.
+The issuer in the JWT is always the actor, thus the care organization doing the request.
+This iss used to find the public key of the issuer from the Nuts registry.
 
 .. note::
 Since the nuts token is signed with the private key of the requester, it is not trivial to verify the signature of the token.
@@ -25,12 +33,36 @@ When recieving a request, any token signature verification steps must be postpon
 
 Sub
 ---
-The subject contains the urn of the requestor (actor). The token has been signed with the private key of the requestor.
-This is to make sure that a token cannot be reused be any other party to make requests in the Nuts network.
+The subject contains the urn of the custodian. The custodian information is used to find the relevant consent (together with actor and subject).
 
-Custodian selection
--------------------
+Aud
+---
+As per `rfc7523 <https://tools.ietf.org/html/rfc7523>`_, the aud must be the token endpoint. This can be taken from the Nuts registry.
 
-A single API endpoint can provide access to the data of multiple care providers (e.g. a multi-tanant SaaS).
-Therefor, when requesting data, an actor needs to provide the custodian of the data it wants to request.
-For now, an actor must provide the **X-Nuts-Custodian** header with the urn based value in the request.
+Usi
+---
+User signature. This is the Irma signature presented to the user. Base64 encoded.
+
+Osi
+---
+Ops signature, optional signature coming from a hardware token, indicating the user belongs to the issuer organization. Can be linked to the Nuts registry.
+
+Ccn
+---
+Client certificate common name. The CN from the client certificate used for the TLS connection which was used for making the request.
+
+Icn
+---
+Common name of the issuer of the ccn. This certificate must be direct verifiable with the Nuts CA tree.
+
+Exp
+---
+Expiration, should be set relatively short since this call is only used to get an access token. Must not be bigger than the validity of the Nuts signature validity.
+
+Iat
+---
+Issued at
+
+Jti
+---
+Unique identifier, secure random number to prevent replay attacks. The authorization server must check this!


### PR DESCRIPTION
JWT token to be used for getting an access token. Token can then be used according to scopes:

- data: user is allowed to retrieve data from the endpoint
- sso: user is allowed to use access token to jump to target application

Signed-off-by: Wout Slakhorst <wout.slakhorst@nedap.com>