### PR TITLE
Support client & CLI mode

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/nuts-auth/engine"
 	crypto "github.com/nuts-foundation/nuts-crypto/pkg"
-	nutsGo "github.com/nuts-foundation/nuts-go-core"
+	core "github.com/nuts-foundation/nuts-go-core"
 	registry "github.com/nuts-foundation/nuts-registry/pkg"
 	"github.com/sirupsen/logrus"
 	"os"
@@ -16,7 +16,7 @@ var rootCmd = e.Cmd
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	c := nutsGo.NutsConfig()
+	c := core.NutsConfig()
 	c.IgnoredPrefixes = append(c.IgnoredPrefixes, e.ConfigKey)
 	c.RegisterFlags(rootCmd, e)
 	if err := c.Load(rootCmd); err != nil {
@@ -40,7 +40,7 @@ func Execute() {
 	}
 
 	r := registry.RegistryInstance()
-	r.Config.Mode = "server"
+	r.Config.Mode = core.ServerEngineMode
 	r.Config.Datadir = "tmp"
 	r.Config.SyncMode = "fs"
 	if err := r.Configure(); err != nil {

--- a/docs/pages/configuration/nuts-auth.rst
+++ b/docs/pages/configuration/nuts-auth.rst
@@ -10,11 +10,11 @@ The following configuration parameters are available for the auth service.
 ===================================     ======================================  ========================================
 Key                                     Default                                 Description
 ===================================     ======================================  ========================================
+auth.mode                               server                                  server or client. nuts-auth doesn't support true client mode (yet), but when specified it doesn't start any services (like IRMA) so that CLI commands can be used.
 auth.publicUrl                          ""                                      Public URL which can be reached by a users IRMA client
-auth.mode                               server                                  server or client, when client it uses the HttpClient
 auth.irmaConfigPath                     ""                                      path to IRMA config folder. If not set, a tmp folder is created
 auth.actingPartyCn                      ""                                      The acting party Common name used in contracts
-auth.skipautoUpdateIrmaSchemas          false                                   set if you want to skip the auto download of the irma schemas every 60 minutes
+auth.skipAutoUpdateIrmaSchemas          false                                   set if you want to skip the auto download of the irma schemas every 60 minutes
 auth.enableCORS                         false                                   Set if you want to allow CORS requests. This is useful when you want browsers to directly communicate with the nuts node
 auth.irmaSchemeManager                  pbdf                                    Allows selecting an IRMA scheme manager. During development this can ben irma-demo. Should be pdfb in strictMode
 ===================================     ======================================  ========================================

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -114,7 +114,7 @@ func flagSet() *pflag.FlagSet {
 	flags.String(pkg.ConfIrmaSchemeManager, "pbdf", "The IRMA schemeManager to use for attributes. Can be either 'pbdf' or 'irma-demo'")
 	flags.String(pkg.ConfAddress, "localhost:1323", "Interface and port for http server to bind to")
 	flags.String(pkg.PublicURL, "", "Public URL which can be reached by a users IRMA client")
-	flags.String(pkg.ConfMode, "server", "server or client, when client it uses the HttpClient")
+	flags.String(pkg.ConfMode, "", "server or client, when client it does not start any services so that CLI commands can be used.")
 	flags.String(pkg.ConfIrmaConfigPath, "", "path to IRMA config folder. If not set, a tmp folder is created.")
 	flags.String(pkg.ConfActingPartyCN, "", "The acting party Common name used in contracts")
 	flags.Bool(pkg.ConfAutoUpdateIrmaSchemas, false, "set if you want to skip the auto download of the irma schemas every 60 minutes.")

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mdp/qrterminal/v3 v3.0.0
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/nuts-foundation/nuts-crypto v0.0.0-20200127075335-afcefe897a71
-	github.com/nuts-foundation/nuts-go-core v0.0.0-20200130105519-4620adf455e9
+	github.com/nuts-foundation/nuts-go-core v0.0.0-20200220093939-3a4292f30472
 	github.com/nuts-foundation/nuts-registry v0.0.0-20200211142433-9d1d2985be8e
 	github.com/pkg/errors v0.8.1
 	github.com/privacybydesign/gabi v0.0.0-20190503104928-ce779395f4c9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/nuts-foundation/nuts-go-core v0.0.0-20191218133145-27ebcf628fab h1:Dx
 github.com/nuts-foundation/nuts-go-core v0.0.0-20191218133145-27ebcf628fab/go.mod h1:+IeGzu5J8qlF4Jcol+mY+MRcLDIfJ8OQnQV4wDp887o=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20200130105519-4620adf455e9 h1:TN63qKwNTLVthdHy0z3FYAfwYoYfR1DEMhCFbjlEfU0=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20200130105519-4620adf455e9/go.mod h1:xltL3S+vqhSMYkTRIWyaVgtDk7y8KIENZmTbVIPIMcw=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20200220093939-3a4292f30472 h1:VxcYvZY14fYJOPEJ3YorptibMU9NLw9UNQfBxEYEJaw=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20200220093939-3a4292f30472/go.mod h1:xltL3S+vqhSMYkTRIWyaVgtDk7y8KIENZmTbVIPIMcw=
 github.com/nuts-foundation/nuts-registry v0.0.0-20191016145829-6bcaa08ad25d h1:0mGb+u8ZjWn5IZadKJ1a+R3Ds5wYDOawB1xUVjZtrso=
 github.com/nuts-foundation/nuts-registry v0.0.0-20191016145829-6bcaa08ad25d/go.mod h1:GoIUJryOXBLSYV1d5gOG3+ksRA2qyVvN2fI67YIWI8g=
 github.com/nuts-foundation/nuts-registry v0.0.0-20191128091042-807cfaf67305 h1:ezT85t2vwJQlhyIU27rYW107BvLpjzzTLPx2UBxu+jE=

--- a/pkg/auth_test.go
+++ b/pkg/auth_test.go
@@ -114,7 +114,7 @@ func TestAuth_Configure(t *testing.T) {
 			Config: AuthConfig{
 			},
 		}
-		i.Configure()
+		_ = i.Configure()
 		assert.Equal(t, core.ServerEngineMode, i.Config.Mode)
 	})
 

--- a/pkg/auth_test.go
+++ b/pkg/auth_test.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	core "github.com/nuts-foundation/nuts-go-core"
 	"testing"
 
 	"errors"
@@ -108,9 +109,30 @@ func TestAuthInstance(t *testing.T) {
 }
 
 func TestAuth_Configure(t *testing.T) {
+	t.Run("mode defaults to server", func(t *testing.T) {
+		i := &Auth{
+			Config: AuthConfig{
+			},
+		}
+		i.Configure()
+		assert.Equal(t, core.ServerEngineMode, i.Config.Mode)
+	})
+
+	t.Run("Configure in client mode", func(t *testing.T) {
+		i := &Auth{
+			Config: AuthConfig{
+				Mode: core.ClientEngineMode,
+			},
+		}
+		
+		assert.NoError(t, i.Configure())
+	})
+
+
 	t.Run("Configure returns error on missing actingPartyCn", func(t *testing.T) {
 		i := &Auth{
 			Config: AuthConfig{
+				Mode:      core.ServerEngineMode,
 				PublicUrl: "url",
 			},
 		}
@@ -121,6 +143,7 @@ func TestAuth_Configure(t *testing.T) {
 	t.Run("Configure returns error on missing publicUrl", func(t *testing.T) {
 		i := &Auth{
 			Config: AuthConfig{
+				Mode:          core.ServerEngineMode,
 				ActingPartyCn: "url",
 			},
 		}
@@ -131,6 +154,7 @@ func TestAuth_Configure(t *testing.T) {
 	t.Run("Configure returns no error on valid config", func(t *testing.T) {
 		i := &Auth{
 			Config: AuthConfig{
+				Mode:                      core.ServerEngineMode,
 				PublicUrl:                 "url",
 				ActingPartyCn:             "url",
 				IrmaConfigPath:            "../testdata/irma",

--- a/pkg/default_validator_test.go
+++ b/pkg/default_validator_test.go
@@ -596,7 +596,7 @@ func defaultValidator() DefaultValidator {
 	if testInstance == nil {
 
 		r := registry.RegistryInstance()
-		r.Config.Mode = "server"
+		r.Config.Mode = core.ServerEngineMode
 		r.Config.Datadir = "tmp"
 		r.Config.SyncMode = "fs"
 		if err := r.Configure(); err != nil {


### PR DESCRIPTION
Fixes #34 

Still starts the REST API (and downloads IRMA schemes as a side effect), but that should be fixed globally in nuts-go.