### PR TITLE
Improve error messages for createSession

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -58,7 +58,7 @@ func (api *Wrapper) CreateSession(ctx echo.Context) error {
 	}
 	// find legal entity in crypto
 	if !api.Auth.KeyExistsFor(orgID) {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unknown legalEntity, is this nuts node managing %s?", orgID))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unknown legalEntity, this Nuts node does not seem to be managing '%s'", orgID))
 	}
 
 	// translate legal entity to its name

--- a/api/api.go
+++ b/api/api.go
@@ -3,10 +3,11 @@ package api
 import (
 	"errors"
 	"fmt"
-	core "github.com/nuts-foundation/nuts-go-core"
 	"net/http"
 	"regexp"
 	"time"
+
+	core "github.com/nuts-foundation/nuts-go-core"
 
 	"github.com/labstack/echo/v4"
 	"github.com/nuts-foundation/nuts-auth/pkg"
@@ -51,13 +52,13 @@ func (api *Wrapper) CreateSession(ctx echo.Context) error {
 		vt = vft
 	}
 
-	// find legal entity in crypto
 	orgID, err := core.ParsePartyID(string(params.LegalEntity))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid legalEntity '%s': %v", params.LegalEntity, err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid value for param legalEntity: '%s', make sure its in the form 'urn:oid:1.2.3.4:foo'", params.LegalEntity))
 	}
+	// find legal entity in crypto
 	if !api.Auth.KeyExistsFor(orgID) {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unknown legalEntity"))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unknown legalEntity, is this nuts node managing %s?", orgID))
 	}
 
 	// translate legal entity to its name


### PR DESCRIPTION
Fixes #93 

New message for incorrect formatted legalEntity param:

```json
{
  "message": "Invalid value for param legalEntity: 'Medisch centrum Oost', make sure its in the form 'urn:oid:1.2.3.4:foo'"
}
```

New message when legalEntity unknown:

```json
{
  "message": "Unknown legalEntity, is this nuts node managing urn:oid:2.16.840.1.113883.2.4.6.1:12345678?"
}
```