### PR TITLE
Fix irma config nullpointer due to incomplete irma init

### DIFF
--- a/pkg/irmaconfig.go
+++ b/pkg/irmaconfig.go
@@ -43,16 +43,9 @@ func GetIrmaConfig(config AuthConfig) (irmaConfig *irma.Configuration, err error
 			return
 		}
 
-		if !config.SkipAutoUpdateIrmaSchemas {
-			logrus.Infof("Downloading irma schemas. If this annoys you or you want to pin the schemas, set %s", ConfSkipAutoUpdateIrmaSchemas)
-			if err = irmaConfig.DownloadDefaultSchemes(); err != nil {
-				return
-			}
-		} else {
-			logrus.Info("Loading irma schemas.")
-			if err = irmaConfig.ParseFolder(); err != nil {
-				return
-			}
+		logrus.Info("Loading irma schemas.")
+		if err = irmaConfig.ParseFolder(); err != nil {
+			return
 		}
 		_irmaConfig = irmaConfig
 	})


### PR DESCRIPTION
Fixes #132

ParseFolder() must always be called according to irma code comments.
Result of migration to 0.5.1